### PR TITLE
Fix config.clean=true exception if output dir doesn't exist yet

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -116,8 +116,16 @@ async function ensureOutputPath(path: string): Promise<void> {
 }
 
 async function deleteDirectory(path: string): Promise<void> {
+  // Check if dir actually exists
   try {
-    await promises.rmdir(path, { recursive: true });
+    await promises.access(path, W_OK);
+  } catch (_err) {
+    return; // nothing to delete
+  }
+
+  try {
+    if (!(await promises.stat(path)).isDirectory()) throw new Error("Path is not a directory!");
+    await promises.rm(path, { recursive: true });
   } catch (err) {
     throw new CliException(
       "Output clean error:\n" + (err as Error).message,


### PR DESCRIPTION
**Checklist**

- [x] read and understood the contributing guidelines
- [x] updated tests
- [x] `npm run build` and `npm test` passes

**Affected core subsystem(s)**
cli

**Description of change**
Fix CLI not running if `config.clean = true` but output directory does not exist yet.
Also fixes `[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`
