### PR TITLE
Allow config.errorFile to be configurable

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ipp/cli",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "An image build orchestrator for the modern web",
   "author": "Marcus Cemes",
   "license": "MIT",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -75,14 +75,21 @@ describe("function startCLI() with custom errorFile", () => {
   });
 
   test("errorFile with custom path", async () => {
-    config.errorFile = "custom/path/error.json";
-    await expect(startCli(config, mockUI)).resolves.toBeUndefined();
-    expect(fs.createWriteStream).toHaveBeenCalledWith(resolve(".", config.errorFile));
+    const errorFile = "custom/path/error.json";
+    await expect(startCli({ errorFile, ...config }, mockUI)).resolves.toBeUndefined();
+    expect(fs.createWriteStream).toHaveBeenCalledWith(resolve(".", errorFile));
   });
 
   test("errorFile disabled", async () => {
-    config.errorFile = false;
-    await expect(startCli(config, mockUI)).resolves.toBeUndefined();
+    const errorFile = false;
+    await expect(startCli({ errorFile, ...config }, mockUI)).resolves.toBeUndefined();
     expect(fs.createWriteStream).toHaveBeenCalledTimes(0);
+  });
+
+  test("errorFile with custom callback function", async () => {
+    const errorFile = jest.fn();
+    await expect(startCli({ errorFile, ...config }, mockUI)).resolves.toBeUndefined();
+    expect(fs.createWriteStream).toHaveBeenCalledTimes(0);
+    expect(errorFile).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,7 +55,14 @@ export async function startCli(config: Config, ui: UI = DynamicUI): Promise<void
 
         setStatus(ctx, Status.PROCESSING);
 
-        await createPipeline(ctx, config, MANIFEST_FILE, ERROR_FILE).pipe(toPromise());
+        await createPipeline(
+          ctx,
+          config,
+          MANIFEST_FILE,
+          typeof config.errorFile === "string" && config.errorFile.length > 0
+            ? config.errorFile
+            : ERROR_FILE
+        ).pipe(toPromise());
 
         setStatus(ctx, Status.COMPLETE);
       } catch (err) {
@@ -100,7 +107,9 @@ function createPipeline(ctx: CliContext, config: Config, manifestFile: string, e
         : passthrough()
     )
     .pipe(exceptionCounter(ctx))
-    .pipe(saveExceptions(resolve(config.output, errorFile)));
+    .pipe(
+      config.errorFile !== false ? saveExceptions(resolve(config.output, errorFile)) : passthrough()
+    );
 }
 
 function setStatus(ctx: CliContext, status: Status) {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -6,7 +6,7 @@
  */
 
 /** Keep synced with package.json */
-export const VERSION = "1.2.8";
+export const VERSION = "1.3.0";
 
 /** Keep synced with package.json */
 export const REPOSITORY = "https://github.com/MarcusCemes/image-processing-pipeline";

--- a/packages/cli/src/init/config.ts
+++ b/packages/cli/src/init/config.ts
@@ -24,6 +24,15 @@ export interface Config {
   clean?: boolean;
   flat?: boolean;
   manifest?: ManifestMappings;
+  /**
+   * Define file path to store errors in json format
+   * (only creates this file if there are actually errors)
+   *
+   * - Keep `undefined` (default) or `true` to create it in outputdir/errors.json
+   * - Use a `string` to change the file path (`./custom-errors.json`)
+   * - Set to `false` to disable creation of errors.json
+   */
+  errorFile?: string | boolean;
 }
 
 export async function getConfig(initial: Partial<Config>, path?: string): Promise<Config> {

--- a/packages/cli/src/init/config.ts
+++ b/packages/cli/src/init/config.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ManifestMappings, Pipeline, PipelineSchema } from "@ipp/common";
+import { Exception, ManifestMappings, Pipeline, PipelineSchema } from "@ipp/common";
 import Ajv, { ErrorObject } from "ajv";
 import chalk from "chalk";
 import { cosmiconfig } from "cosmiconfig";
@@ -28,11 +28,12 @@ export interface Config {
    * Define file path to store errors in json format
    * (only creates this file if there are actually errors)
    *
-   * - Keep `undefined` (default) or `true` to create it in outputdir/errors.json
+   * - Keep `undefined` (default) or use `true` to create it in <outputdir>/errors.json
    * - Use a `string` to change the file path (`./custom-errors.json`)
    * - Set to `false` to disable creation of errors.json
+   * - Use a callback function which takes as input each exception item, e.g: `(item) => console.error(item)`
    */
-  errorFile?: string | boolean;
+  errorFile?: string | boolean | ((item: Exception) => void);
 }
 
 export async function getConfig(initial: Partial<Config>, path?: string): Promise<Config> {

--- a/packages/cli/src/init/config.ts
+++ b/packages/cli/src/init/config.ts
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Exception, ManifestMappings, Pipeline, PipelineSchema } from "@ipp/common";
+import { ManifestMappings, Pipeline, PipelineSchema } from "@ipp/common";
 import Ajv, { ErrorObject } from "ajv";
 import chalk from "chalk";
 import { cosmiconfig } from "cosmiconfig";
 import { CliException, CliExceptionCode } from "../lib/exception";
+import { ExceptionFn } from "../operators/exceptions";
 import configSchema from "../schema/config.json";
 import defaultConfig from "./default_config.json";
 
@@ -24,16 +25,14 @@ export interface Config {
   clean?: boolean;
   flat?: boolean;
   manifest?: ManifestMappings;
+  /** Suppress the output of any image processing errors. */
+  suppressErrors?: boolean;
   /**
-   * Define file path to store errors in json format
-   * (only creates this file if there are actually errors)
-   *
-   * - Keep `undefined` (default) or use `true` to create it in <outputdir>/errors.json
-   * - Use a `string` to change the file path (`./custom-errors.json`)
-   * - Set to `false` to disable creation of errors.json
-   * - Use a callback function which takes as input each exception item, e.g: `(item) => console.error(item)`
+   * Specify a different filename to output processing errors to
+   * (in JSON format), or a callback function that receives the
+   * exception as its first parameter.
    */
-  errorFile?: string | boolean | ((item: Exception) => void);
+  errorOutput?: string | ExceptionFn;
 }
 
 export async function getConfig(initial: Partial<Config>, path?: string): Promise<Config> {

--- a/packages/cli/src/operators/exceptions.ts
+++ b/packages/cli/src/operators/exceptions.ts
@@ -7,16 +7,41 @@
 
 import { Exception } from "@ipp/common";
 import { createWriteStream } from "fs";
+import { resolve } from "path";
 import { CliException } from "../lib/exception";
 import { Operator } from "../lib/stream/object_stream";
 import { map } from "../lib/stream/operators/map";
 
+const DEFAULT_ERROR_FILE = "errors.json";
+
+export type ExceptionFn = (exception: Exception) => void | Promise<void>;
+
 interface ExceptionWriter {
-  write: (exception: Exception) => void;
+  write: ExceptionFn;
   end: () => void;
 }
 
-export function saveExceptions<T>(path: string): Operator<T | Exception, T> {
+export function exceptionHandler<T>(
+  outputPath: string,
+  target?: string | ExceptionFn
+): Operator<T | Exception, T> {
+  switch (typeof target) {
+    case "string": {
+      const path = resolve(outputPath, target);
+      return saveExceptions(path);
+    }
+
+    case "function":
+      return mapExceptions(target);
+
+    default: {
+      const path = resolve(outputPath, DEFAULT_ERROR_FILE);
+      return saveExceptions(path);
+    }
+  }
+}
+
+function saveExceptions<T>(path: string): Operator<T | Exception, T> {
   let writer: ExceptionWriter | null = null;
 
   return map<T | Exception, T>(
@@ -31,16 +56,6 @@ export function saveExceptions<T>(path: string): Operator<T | Exception, T> {
 
     () => writer?.end()
   );
-}
-
-export function callbackExceptions<T>(
-  callback: (item: Exception) => void
-): Operator<T | Exception, T> {
-  return map<T | Exception, T>((item) => {
-    if (!(item instanceof Exception)) return item;
-    callback(item);
-    return null;
-  });
 }
 
 function createExceptionWriter(path: string): ExceptionWriter {
@@ -79,4 +94,15 @@ function createExceptionWriter(path: string): ExceptionWriter {
       stream.end();
     },
   };
+}
+
+function mapExceptions<T>(callback: ExceptionFn): Operator<T | Exception, T> {
+  return map<T | Exception, T>(async (item) => {
+    if (!(item instanceof Exception)) {
+      return item;
+    }
+
+    await callback(item);
+    return null;
+  });
 }

--- a/packages/cli/src/operators/exceptions.ts
+++ b/packages/cli/src/operators/exceptions.ts
@@ -33,6 +33,16 @@ export function saveExceptions<T>(path: string): Operator<T | Exception, T> {
   );
 }
 
+export function callbackExceptions<T>(
+  callback: (item: Exception) => void
+): Operator<T | Exception, T> {
+  return map<T | Exception, T>((item) => {
+    if (!(item instanceof Exception)) return item;
+    callback(item);
+    return null;
+  });
+}
+
 function createExceptionWriter(path: string): ExceptionWriter {
   let first = true;
   const stream = createWriteStream(path);


### PR DESCRIPTION
**Checklist**

- [x] read and understood the contributing guidelines
- [X] updated tests
- [X] updated documentation (PR https://github.com/MarcusCemes/image-processing-pipeline-website/pull/1)
- [X] `npm run build` and `npm test` passes

**Affected core subsystem(s)**
- cli

**Description of change**
Added feature to configure `config.errorFile`:
- can be disabled with `false`
- file path can be overriden via `string`
- a callback function can be used, to either log to console or do something else

** Usecase **
I use ipp as a CLI tool and during development I can simply log out the errors in the console instead of a file
On my build server, I set it to false to ensure no file is created
The custom path can also be used to centralize errors.json in case ipp is called multiple times.