### PR TITLE
Conditional pipe execution

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -19,6 +19,7 @@ import { passthrough } from "./lib/stream/operators/passthrough";
 import { toPromise } from "./lib/stream/operators/to_promise";
 import { completedCounter, exceptionCounter, sourceCounter } from "./operators/counters";
 import { exceptionHandler } from "./operators/exceptions";
+import { filterImages } from "./operators/filter";
 import { saveManifest } from "./operators/manifest";
 import { processImages } from "./operators/process";
 import { saveImages } from "./operators/save";
@@ -87,6 +88,7 @@ function createPipeline(ctx: CliContext, config: Config, manifestFile: string) {
   const paths = typeof config.input === "string" ? [config.input] : config.input;
 
   return searchForImages(paths)
+    .pipe(filterImages(config.inputFilter))
     .pipe(sourceCounter(ctx))
     .pipe(buffer(BUFFER_SIZE))
     .pipe(processImages(config.pipeline, config.concurrency))

--- a/packages/cli/src/init/config.ts
+++ b/packages/cli/src/init/config.ts
@@ -16,8 +16,19 @@ import defaultConfig from "./default_config.json";
 
 const MODULE_NAME = "ipp";
 
+/**
+ * Callback function which must return true to include the image for processing
+ */
+export type InputFilterCallback = (file: string) => boolean;
+
+/**
+ * Filter which can exclude images from processing
+ */
+export type InputFilter = (InputFilterCallback | RegExp)[] | InputFilterCallback | RegExp;
+
 export interface Config {
   input: string | string[];
+  inputFilter?: InputFilter;
   output: string;
   pipeline: Pipeline;
 

--- a/packages/cli/src/lib/stream/operators/filter.ts
+++ b/packages/cli/src/lib/stream/operators/filter.ts
@@ -1,0 +1,30 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createObjectStream, Operator } from "../object_stream";
+
+export function filter<I, O>(
+  fn: (item: I) => boolean | Promise<boolean>,
+  complete?: () => void | Promise<void>
+): Operator<I, O> {
+  return (source) =>
+    createObjectStream(
+      (async function* () {
+        for await (const item of source) {
+          if (!(await fn(item))) continue;
+
+          if (Array.isArray(item)) {
+            for (const result of item) yield result;
+          } else {
+            yield item;
+          }
+        }
+
+        if (complete) await complete();
+      })()
+    );
+}

--- a/packages/cli/src/operators/filter.test.ts
+++ b/packages/cli/src/operators/filter.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Exception } from "../../../common/src/exception";
+import { createObjectStream, ObjectStream } from "../lib/stream/object_stream";
+import { filterImages } from "./filter";
+import { isTaskSource, TaskSource } from "./types";
+
+const imgTask = (iOrFilename: number | string, root = "/root") => ({
+  root,
+  file: typeof iOrFilename === "number" ? `file-${iOrFilename}.png` : iOrFilename,
+});
+
+const awaitAsyncIterable = async (source: AsyncIterable<TaskSource | Exception>) => {
+  const resolved: {
+    tasks: TaskSource[];
+    exceptions: Exception[];
+  } = {
+    tasks: [],
+    exceptions: [],
+  };
+  for await (const tsk of source) {
+    if (isTaskSource(tsk)) resolved.tasks.push(tsk);
+    else if (tsk instanceof Exception) resolved.exceptions.push(tsk);
+  }
+  return resolved;
+};
+
+function imageObjectStreams(
+  amountOrList: number | string[] = 5
+): ObjectStream<TaskSource | Exception> {
+  return createObjectStream(imageAsyncGenerator(amountOrList));
+}
+
+async function* imageAsyncGenerator(
+  amountOrList: number | string[]
+): AsyncGenerator<TaskSource | Exception> {
+  if (typeof amountOrList === "number") {
+    for (let i = 0; i < amountOrList; i++) {
+      yield imgTask(i);
+    }
+  } else {
+    for (const name of amountOrList) {
+      yield name.startsWith("exception-") ? new Exception(name) : imgTask(name);
+    }
+  }
+}
+
+describe("filter.ts", () => {
+  const imageAmount = 10;
+
+  afterEach(() => jest.clearAllMocks());
+
+  test("should pass through images if no filter is supplied", async () => {
+    const stream = imageObjectStreams(imageAmount).pipe(filterImages());
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(imageAmount);
+  });
+
+  test("should filter via RegExp", async () => {
+    const stream = imageObjectStreams(imageAmount).pipe(filterImages(/file-[2-4]\.png$/));
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(3);
+    expect(result.tasks).toStrictEqual([imgTask(2), imgTask(3), imgTask(4)]);
+    expect(result.exceptions).toHaveLength(0);
+  });
+
+  test("should handle exceptions", async () => {
+    const stream = imageObjectStreams([
+      "exception-1",
+      "file-2.png",
+      "file-3.png",
+      "file-4.png",
+    ]).pipe(filterImages(/file-3\.png$/));
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks).toStrictEqual([imgTask(3)]);
+    expect(result.exceptions).toHaveLength(1);
+  });
+
+  test("should filter via multiple RegExp", async () => {
+    const stream = imageObjectStreams(imageAmount).pipe(
+      filterImages([/file-[2-4]\.png$/, /file-[^3]\.png$/])
+    );
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks).toStrictEqual([imgTask(2), imgTask(4)]);
+  });
+
+  test("should filter via callback", async () => {
+    const stream = imageObjectStreams(imageAmount).pipe(filterImages((f) => f.endsWith("4.png")));
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks).toStrictEqual([imgTask(4)]);
+  });
+
+  test("should filter via callback & regexp", async () => {
+    const imgList = ["other.gif"]
+      .concat([1, 2, 3, 4, 5].map((i) => `file-${i}.png`))
+      .concat([1, 2, 3, 4, 5].map((i) => `file-${i}.jpg`));
+    const stream = imageObjectStreams(imgList).pipe(
+      filterImages([(f) => f.endsWith(".png"), /file-[25]\.png$/])
+    );
+
+    const result = await awaitAsyncIterable(stream);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.tasks).toStrictEqual([imgTask(2), imgTask(5)]);
+  });
+});

--- a/packages/cli/src/operators/filter.ts
+++ b/packages/cli/src/operators/filter.ts
@@ -1,0 +1,34 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { resolve } from "path";
+import { InputFilter } from "../init/config";
+import { Operator } from "../lib/stream/object_stream";
+import { filter } from "../lib/stream/operators/filter";
+import { isTaskSource } from "./types";
+
+export function filterImages<T>(inputFilter?: InputFilter): Operator<T, T> {
+  return filter((item) => {
+    if (!inputFilter || !isTaskSource(item)) {
+      console.log(item);
+      return true;
+    }
+
+    if (!Array.isArray(inputFilter)) {
+      inputFilter = [inputFilter];
+    }
+
+    const file = resolve(item.root, item.file);
+    for (const f of inputFilter) {
+      if (typeof f === "function" ? !f(file) : !f.test(file)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}

--- a/packages/cli/src/operators/filter.ts
+++ b/packages/cli/src/operators/filter.ts
@@ -14,7 +14,6 @@ import { isTaskSource } from "./types";
 export function filterImages<T>(inputFilter?: InputFilter): Operator<T, T> {
   return filter((item) => {
     if (!inputFilter || !isTaskSource(item)) {
-      console.log(item);
       return true;
     }
 

--- a/packages/cli/src/operators/process.test.ts
+++ b/packages/cli/src/operators/process.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { PassThrough } from "stream";
+import { Stats } from "fs";
+import { CompletedTask, isCompletedTask, isSavedResult, SavedResult } from "./types";
+import { createObjectStream } from "../lib/stream/object_stream";
+import { Exception } from "../../../common/src/exception";
+import { Metadata, PrimitiveValue, sampleMetadata } from "@ipp/common";
+import { processImages } from "./process";
+
+// mock sharp (the complicated way)
+jest.mock("../../../core/node_modules/sharp", () => {
+  const mockSharp = () => ({
+    metadata: jest.fn(() => ({ width: 128, height: 128, channels: 3, format: "png" })),
+  });
+  mockSharp.concurrency = jest.fn(() => 1);
+  return mockSharp;
+});
+
+jest.mock("fs", () => ({
+  createReadStream: jest.fn(() => {
+    const stream = new PassThrough();
+    stream.end();
+    return stream;
+  }),
+  createWriteStream: jest.fn(() => new PassThrough()),
+  existsSync: jest.fn(() => true),
+  promises: {
+    readFile: jest.fn(async () => Buffer.from("content")),
+    access: jest.fn(async () => []),
+    stat: jest.fn(
+      async () =>
+        <Partial<Stats>>{
+          isFile: jest.fn(() => false),
+          isDirectory: jest.fn(() => true),
+          mtimeMs: 1000,
+        }
+    ),
+  },
+}));
+
+const awaitTaskSource = async (source: AsyncIterable<Exception | CompletedTask | SavedResult>) => {
+  const resolved: {
+    completed: CompletedTask[];
+    saved: SavedResult[];
+    error: Exception[];
+  } = {
+    completed: [],
+    error: [],
+    saved: [],
+  };
+  for await (const tsk of source) {
+    if (isCompletedTask(tsk)) resolved.completed.push(tsk);
+    else if (isSavedResult(tsk)) resolved.saved.push(tsk);
+    else if (tsk instanceof Exception) resolved.error.push(tsk);
+  }
+  return resolved;
+};
+const asyncIterableImageTasks = async function* (amount = 1) {
+  const metadata: Metadata<Record<string, PrimitiveValue>> = sampleMetadata(128, "png");
+  for (let i = 0; i < amount; i++) {
+    yield {
+      file: `test-${i}.png`,
+      result: {
+        source: {
+          buffer: Buffer.from("content"),
+          metadata,
+        },
+        formats: [{ data: { buffer: Buffer.from("content"), metadata }, saveKey: true }],
+      },
+      root: "/input/root",
+    };
+  }
+};
+
+const JestTestPipe = jest.fn(async (data) => data);
+const JestTestThenPipe = jest.fn(async (data) => data);
+
+describe("process.ts", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test("should not process images if 'test = false'", async () => {
+    const stream = createObjectStream(asyncIterableImageTasks()).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: false,
+          },
+        ],
+        1
+      )
+    );
+
+    const result = await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(0);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  test("should process images if 'test = undefined' (default behavior)", async () => {
+    const stream = createObjectStream(asyncIterableImageTasks()).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+          },
+        ],
+        1
+      )
+    );
+
+    const result = await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(1);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  test("should process images if 'test = true'", async () => {
+    const stream = createObjectStream(asyncIterableImageTasks()).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: true,
+          },
+        ],
+        1
+      )
+    );
+
+    const result = await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(1);
+    expect(result.completed).toHaveLength(1);
+  });
+
+  test("should process images if 'test = callback' returns truthy", async () => {
+    const testCallback = jest.fn((path) => {
+      return path === "test-1.png" || path === "test-3.png";
+    });
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: testCallback,
+          },
+        ],
+        1
+      )
+    );
+
+    const result = await awaitTaskSource(stream);
+    expect(testCallback).toHaveBeenCalledTimes(5);
+    expect(JestTestPipe).toHaveBeenCalledTimes(2);
+    expect(JestTestPipe.mock.calls[0][0].metadata.source.path).toStrictEqual("test-1.png");
+    expect(JestTestPipe.mock.calls[1][0].metadata.source.path).toStrictEqual("test-3.png");
+    expect(result.completed).toHaveLength(5);
+  });
+
+  test("should process images if 'test = callback' returns truthy", async () => {
+    const testCallback = jest.fn((path) => {
+      return path === "test-1.png" || path === "test-3.png";
+    });
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: testCallback,
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(testCallback).toHaveBeenCalledTimes(5);
+    expect(JestTestPipe).toHaveBeenCalledTimes(2);
+    expect(JestTestPipe.mock.calls[0][0].metadata.source.path).toStrictEqual("test-1.png");
+    expect(JestTestPipe.mock.calls[1][0].metadata.source.path).toStrictEqual("test-3.png");
+  });
+
+  test("should process images if 'test = <path>' equals path of file", async () => {
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: "test-2.png",
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(1);
+    expect(JestTestPipe.mock.calls[0][0].metadata.source.path).toStrictEqual("test-2.png");
+  });
+
+  test("should process images if 'test = /RegExp/' returns truthy", async () => {
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: /test-[3|4]\.png/,
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(2);
+    expect(JestTestPipe.mock.calls[0][0].metadata.source.path).toStrictEqual("test-3.png");
+    expect(JestTestPipe.mock.calls[1][0].metadata.source.path).toStrictEqual("test-4.png");
+  });
+
+  test("should process images if all test rules return truthy", async () => {
+    const testCallback = jest.fn((path) => {
+      return path === "test-4.png";
+    });
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: [/test-[3|4]\.png/, testCallback],
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(testCallback).toHaveBeenCalledTimes(2);
+    expect(JestTestPipe).toHaveBeenCalledTimes(1);
+    expect(JestTestPipe.mock.calls[0][0].metadata.source.path).toStrictEqual("test-4.png");
+  });
+
+  test("should process pipeline.then only if test passes", async () => {
+    const testCallback = jest.fn((path) => {
+      return path.includes("test-4");
+    });
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: /test-[2-4]\.png/,
+            then: [
+              {
+                pipe: JestTestThenPipe,
+                test: testCallback,
+              },
+            ],
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(JestTestPipe).toHaveBeenCalledTimes(3);
+    expect(testCallback).toHaveBeenCalledTimes(3);
+    expect(JestTestThenPipe).toHaveBeenCalledTimes(1);
+  });
+
+  test("should process complex pipeline tree properly", async () => {
+    const testCallback1 = jest.fn((path) => /test-[1-2]\.png/.test(path));
+    const testThenCallback1 = jest.fn(() => true);
+    const testCallback2 = jest.fn((path) => /test-[3-4]\.png/.test(path));
+    const testThenCallback2 = jest.fn((path) => path.startsWith("test-3"));
+    const stream = createObjectStream(asyncIterableImageTasks(5)).pipe(
+      processImages(
+        [
+          {
+            pipe: JestTestPipe,
+            test: testCallback1,
+            then: [
+              {
+                pipe: JestTestThenPipe,
+                test: testThenCallback1,
+              },
+            ],
+          },
+          {
+            pipe: JestTestPipe,
+            test: testCallback2,
+            then: [
+              {
+                pipe: JestTestThenPipe,
+                test: testThenCallback2,
+              },
+            ],
+          },
+        ],
+        1
+      )
+    );
+
+    await awaitTaskSource(stream);
+    expect(testCallback1).toHaveBeenCalledTimes(5); // 0,1,2,3
+    expect(testCallback2).toHaveBeenCalledTimes(5); // 0,1,2,3
+    expect(JestTestPipe).toHaveBeenCalledTimes(4); // 1,2 | 3,4
+
+    expect(testThenCallback1).toHaveBeenCalledTimes(2); // 1,2
+    expect(testThenCallback2).toHaveBeenCalledTimes(2); // 3,4
+    expect(JestTestThenPipe).toHaveBeenCalledTimes(3); // 1,2 | 3
+  });
+});

--- a/packages/common/src/pipeline.ts
+++ b/packages/common/src/pipeline.ts
@@ -51,6 +51,21 @@ export interface PipelineResult {
 }
 
 /**
+ * PipelineTest type which decides if the given file is executed for the pipeline
+ */
+export type PipelineTest =
+  | Array<PipelineTestCallback | RegExp>
+  | string
+  | PipelineTestCallback
+  | RegExp
+  | boolean;
+
+/**
+ * Callback function which is executed on each image to test if the given file should be processed by the pipeline
+ */
+export type PipelineTestCallback = (filepath: string, metadata: Metadata) => boolean;
+
+/**
  * The template of a single branch of a pipeline schema. It may only have one input, but the
  * result of the first pipe may be sent to multiple consecutive pipes.
  *
@@ -60,6 +75,15 @@ export interface PipelineResult {
 export interface PipelineBranch<O = any> {
   pipe: string | { resolve: string; module?: string } | Pipe;
   options?: O;
+  /**
+   * (Optional) Test each file if the given pipeline should be executed on it.
+   *
+   * - A string to strict equal test the relative file path against it `filepath === test`
+   * - A callback function with the relative file path and metadata as argument. `(filepath, metadata) => boolean`
+   * - A RegExp to test the relative file path against it `/.+/.test(filepath)`
+   * - A boolean. `True` executes the pipeline and `false` will skip it.
+   */
+  test?: PipelineTest;
   save?: PrimitiveValue;
   then?: Pipeline;
 }


### PR DESCRIPTION
**Checklist**

- [x] read and understood the contributing guidelines
- [x] updated tests
- [x] updated documentation (https://github.com/MarcusCemes/image-processing-pipeline-website/pull/2)
- [x] `npm run build` and `npm test` passes

**Affected core subsystem(s)**
core & cli

**Description of change**
Added a test parameter, to allow one CLI execution to handle different files based on conditions.
For example, this allows to use different settings based on filename, etc.

It is a bit old and I'm not sure if I'm feature complete yet, would love to get some feedback and suggestions if I should add something.
