### PR TITLE
Add rotate pipe

### DIFF
--- a/packages/core/src/pipes/index.ts
+++ b/packages/core/src/pipes/index.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Pipe } from '@ipp/common';
+import { Pipe } from "@ipp/common";
 
-import { ConvertPipe } from './convert';
-import { PassthroughPipe } from './passthrough';
-import { ResizePipe } from './resize';
-import { RotatePipe } from './rotate';
+import { ConvertPipe } from "./convert";
+import { PassthroughPipe } from "./passthrough";
+import { ResizePipe } from "./resize";
+import { RotatePipe } from "./rotate";
 
 export const PIPES: { [index: string]: Pipe<any> } = {
   convert: ConvertPipe,

--- a/packages/core/src/pipes/index.ts
+++ b/packages/core/src/pipes/index.ts
@@ -5,14 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Pipe } from "@ipp/common";
+import { Pipe } from '@ipp/common';
 
-import { ConvertPipe } from "./convert";
-import { PassthroughPipe } from "./passthrough";
-import { ResizePipe } from "./resize";
+import { ConvertPipe } from './convert';
+import { PassthroughPipe } from './passthrough';
+import { ResizePipe } from './resize';
+import { RotatePipe } from './rotate';
 
 export const PIPES: { [index: string]: Pipe<any> } = {
   convert: ConvertPipe,
   passthrough: PassthroughPipe,
   resize: ResizePipe,
+  rotate: RotatePipe,
 } as const;

--- a/packages/core/src/pipes/rotate.test.ts
+++ b/packages/core/src/pipes/rotate.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { DataObject, sampleMetadata } from '@ipp/common';
+import { DataObject, sampleMetadata } from "@ipp/common";
 
-import { randomBytes } from 'crypto';
-import sharp, { OutputInfo, Sharp } from 'sharp';
+import { randomBytes } from "crypto";
+import sharp, { OutputInfo, Sharp } from "sharp";
 
-import { RotateOptions, RotatePipe } from './rotate';
+import { RotateOptions, RotatePipe } from "./rotate";
 
 jest.mock("sharp");
 

--- a/packages/core/src/pipes/rotate.test.ts
+++ b/packages/core/src/pipes/rotate.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { DataObject, sampleMetadata } from '@ipp/common';
+
+import { randomBytes } from 'crypto';
+import sharp, { OutputInfo, Sharp } from 'sharp';
+
+import { RotateOptions, RotatePipe } from './rotate';
+
+jest.mock("sharp");
+
+type UnPromise<T> = T extends Promise<infer U> ? U : never;
+
+describe("built-in rotate pipe", () => {
+  /** The input value */
+  const data: DataObject = {
+    buffer: randomBytes(8),
+    metadata: sampleMetadata(256, "jpeg"),
+  };
+
+  const rotateOptions = <RotateOptions>{ angle: 45 };
+
+  /** The return value of the mocked sharp.toBuffer() function */
+  const toBufferResult: UnPromise<ReturnType<Sharp["toBuffer"]>> = {
+    data: data.buffer,
+    info: {
+      width: 256,
+      height: 256,
+      channels: data.metadata.current.channels,
+      size: data.buffer.length,
+      format: data.metadata.current.format,
+      premultiplied: false,
+    } as OutputInfo,
+  };
+
+  /** The expected value */
+  const newData: DataObject = {
+    ...data,
+    metadata: {
+      ...data.metadata,
+      current: {
+        ...data.metadata.current,
+        width: toBufferResult.info.width,
+        height: toBufferResult.info.height,
+      },
+    },
+  };
+
+  const toBufferMock = jest.fn(async () => toBufferResult);
+  const rotateMock = jest.fn(() => ({ toBuffer: toBufferMock }));
+  const sharpMock = sharp as unknown as jest.Mock<{ rotate: typeof rotateMock }>;
+  const mocks = [toBufferMock, rotateMock, sharpMock];
+
+  beforeAll(() => sharpMock.mockImplementation(() => ({ rotate: rotateMock })));
+  afterAll(() => sharpMock.mockRestore());
+  afterEach(() => mocks.forEach((m) => m.mockClear()));
+
+  test("rotate image", async () => {
+    const result = RotatePipe(data, rotateOptions);
+
+    await expect(result).resolves.toMatchObject<DataObject>(newData);
+
+    expect(rotateMock).toHaveBeenCalledWith(rotateOptions.angle, rotateOptions?.rotateOptions);
+    expect(toBufferMock).toHaveBeenCalledWith({ resolveWithObject: true });
+  });
+});

--- a/packages/core/src/pipes/rotate.ts
+++ b/packages/core/src/pipes/rotate.ts
@@ -1,0 +1,43 @@
+/**
+ * Image Processing Pipeline - Copyright (c) Marcus Cemes
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Pipe } from '@ipp/common';
+
+import produce from 'immer';
+import sharp, { RotateOptions as SharpOptions } from 'sharp';
+
+sharp.concurrency(1);
+
+export interface RotateOptions {
+  angle?: number;
+  rotateOptions?: SharpOptions;
+}
+
+/**
+ * A built-in pipe that lets you rotate an image
+ * This can be used to rotate the image properly before the EXIF data is removed from CompressPipe
+ */
+export const RotatePipe: Pipe<RotateOptions> = async (data, options = {}) => {
+  const {
+    data: newBuffer,
+    info: { width, height, format, channels },
+  } = await sharp(data.buffer)
+    .rotate(options.angle, options.rotateOptions)
+    .toBuffer({ resolveWithObject: true });
+
+  const newMetadata = produce(data.metadata, (draft) => {
+    draft.current.width = width;
+    draft.current.height = height;
+    draft.current.channels = channels;
+    draft.current.format = format;
+  });
+
+  return {
+    buffer: newBuffer,
+    metadata: newMetadata,
+  };
+};

--- a/packages/core/src/pipes/rotate.ts
+++ b/packages/core/src/pipes/rotate.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Pipe } from '@ipp/common';
+import { Pipe } from "@ipp/common";
 
-import produce from 'immer';
-import sharp, { RotateOptions as SharpOptions } from 'sharp';
+import produce from "immer";
+import sharp, { RotateOptions as SharpOptions } from "sharp";
 
 sharp.concurrency(1);
 


### PR DESCRIPTION
**Checklist**

- [X] read and understood the contributing guidelines
- [x] updated tests
- [x] updated documentation (skipped, all pipes must be documented later on)
- [x] `npm run build` and `npm test` passes

**Affected core subsystem(s)**
core

**Description of change**
Added a basic rotate pipe (https://sharp.pixelplumbing.com/api-operation#rotate) because images (from Smartphone for example) will loose rotation information due to compress. In order to fix this, a rotate will be made before which takes the EXIF data into account if no arguments are provided. (see https://stackoverflow.com/questions/48716266/sharp-image-library-rotates-image-when-resizing)

It was a copy paste from the resize pipe, but it does it's job nicely.
Eventually in the future it would be great to offer an advanced pipe, which exposes a sharp instance and allows to chain multiple sharp operations together. ;)

@MarcusCemes is this `sharp.concurrency(1);` needed in each core pipe at the top? Is this used because ipp already exposes it's own concurrency?